### PR TITLE
Fix tsc build by excluding Next.js UI

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -104,5 +104,13 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": [
+    "agent.ts",
+    "index.ts",
+    "seed-database.ts"
+  ],
+  "exclude": [
+    "ui"
+  ]
 }


### PR DESCRIPTION
## Summary
- exclude the `ui` directory from the root TypeScript compilation
- only compile the server `.ts` files

This prevents `tsc` from trying to compile the Next.js project and allows `npx tsc` to run without errors.

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_b_6883f7c9ad7883298cdb753dacd4b57f