### PR TITLE
Add simple web UI for agent

### DIFF
--- a/agent.ts
+++ b/agent.ts
@@ -132,7 +132,11 @@ export async function callAgent(client: MongoClient, query: string, thread_id: s
   );
 
   // console.log(JSON.stringify(finalState.messages, null, 2));
-  console.log(finalState.messages[finalState.messages.length - 1].content);
+  const finalAnswer = finalState.messages[finalState.messages.length - 1].content;
+  console.log(finalAnswer);
 
-  return finalState.messages[finalState.messages.length - 1].content;
+  return {
+    finalAnswer,
+    trace: finalState.messages,
+  };
 }

--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,13 @@
 import 'dotenv/config';
 import express, { Express, Request, Response } from "express";
+import path from "path";
 import { MongoClient } from "mongodb";
 import { callAgent } from './agent';
 import { seedDatabaseIfNeeded } from './seed-database';
 
 const app: Express = express();
 app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
 
 // Initialize MongoDB client
 const client = new MongoClient(process.env.MONGODB_ATLAS_URI as string);
@@ -18,10 +20,9 @@ async function startServer() {
 
     await seedDatabaseIfNeeded(client);
 
-    // Set up basic Express route
-    // curl -X GET http://localhost:3000/
+    // Serve the simple web UI
     app.get('/', (req: Request, res: Response) => {
-      res.send('LangGraph Agent Server');
+      res.sendFile(path.join(__dirname, 'public', 'index.html'));
     });
 
     // API endpoint to start a new conversation
@@ -30,8 +31,8 @@ async function startServer() {
       const initialMessage = req.body.message;
       const threadId = Date.now().toString(); // Simple thread ID generation
       try {
-        const response = await callAgent(client, initialMessage, threadId);
-        res.json({ threadId, response });
+        const { finalAnswer, trace } = await callAgent(client, initialMessage, threadId);
+        res.json({ threadId, response: finalAnswer, trace });
       } catch (error) {
         console.error('Error starting conversation:', error);
         res.status(500).json({ error: 'Internal server error' });
@@ -44,8 +45,8 @@ async function startServer() {
       const { threadId } = req.params;
       const { message } = req.body;
       try {
-        const response = await callAgent(client, message, threadId);
-        res.json({ response });
+        const { finalAnswer, trace } = await callAgent(client, message, threadId);
+        res.json({ response: finalAnswer, trace });
       } catch (error) {
         console.error('Error in chat:', error);
         res.status(500).json({ error: 'Internal server error' });

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>LangGraph Agent UI</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 600px; margin: 2rem auto; }
+    #messages { height: 300px; overflow-y: auto; border: 1px solid #ccc; padding: 1rem; background: #fff; }
+    .msg { margin-bottom: 0.5rem; }
+    #trace { white-space: pre-wrap; background: #f5f5f5; padding: 1rem; margin-top: 1rem; border: 1px solid #ccc; height: 200px; overflow-y: auto; }
+  </style>
+</head>
+<body>
+  <h1>LangGraph Agent UI</h1>
+  <div id="messages"></div>
+  <div style="display:flex;margin-top:1rem;">
+    <input id="userInput" style="flex-grow:1;margin-right:0.5rem;" placeholder="Type your request" />
+    <button id="sendBtn">Send</button>
+  </div>
+  <h2>Trace</h2>
+  <div id="trace"></div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,39 @@
+let threadId = null;
+const messagesDiv = document.getElementById('messages');
+const traceDiv = document.getElementById('trace');
+const input = document.getElementById('userInput');
+const sendBtn = document.getElementById('sendBtn');
+
+function appendMessage(role, text) {
+  const div = document.createElement('div');
+  div.className = 'msg';
+  div.textContent = `${role}: ${text}`;
+  messagesDiv.appendChild(div);
+  messagesDiv.scrollTop = messagesDiv.scrollHeight;
+}
+
+async function sendMessage() {
+  const value = input.value.trim();
+  if (!value) return;
+  appendMessage('You', value);
+  input.value = '';
+  const endpoint = threadId ? `/chat/${threadId}` : '/chat';
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: value })
+  });
+  const data = await res.json();
+  if (res.ok) {
+    if (!threadId) threadId = data.threadId;
+    appendMessage('Agent', data.response);
+    traceDiv.textContent = JSON.stringify(data.trace, null, 2);
+  } else {
+    appendMessage('Agent', data.error || 'Error');
+  }
+}
+
+sendBtn.addEventListener('click', sendMessage);
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') sendMessage();
+});


### PR DESCRIPTION
## Summary
- return detailed info from `callAgent`
- serve a basic HTML interface from Express
- add frontend JS for sending requests and showing traces

## Testing
- `npx tsc --noEmit`
- `npm run build` in `ui`

------
https://chatgpt.com/codex/tasks/task_b_6884671d628c8329bdf9b06eed28254f